### PR TITLE
docs(glossary): scaffold per-module glossary writer task (#107)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -27,6 +27,7 @@ This file is the current actionable backlog. Completed historical refactor steps
   - [ ] `fileArtifacts.js`
   - [ ] `reportArtifacts.js`
 - [ ] label any `progress-report.md` snapshots as historical when they exist
+- [ ] writer task: per-module glossary for `assembler.js`, `interpreter.js`, `linker.js` (parent #107; spike+write puzzles #108–#113; stubs in `docs/glossary/`)
 
 ## Oracle Parity and Research
 

--- a/docs/glossary/README.md
+++ b/docs/glossary/README.md
@@ -1,0 +1,34 @@
+# LCC.js Glossary
+
+Per-module glossaries of LCC-specific vocabulary. Aimed at newcomers who already
+understand general assembler / VM / linker concepts and need the
+**LCC-specific** angle (load point, listing load point, adjustment entries,
+externs vs globals, .e/.bst/.lst formats, ISA opcode nibble layout, loop
+detection, etc.).
+
+## Files
+
+| File | Source it documents | Status |
+|---|---|---|
+| [`assembler.md`](./assembler.md) | `src/core/assembler.js` | stub (see #108, #111) |
+| [`interpreter.md`](./interpreter.md) | `src/core/interpreter.js` | stub (see #109, #112) |
+| [`linker.md`](./linker.md) | `src/core/linker.js` | stub (see #110, #113) |
+
+Parent tracker: #107. Originally requested in #9.
+
+## Entry convention
+
+Each term entry should follow this shape:
+
+```markdown
+### term-name
+
+1–3 sentence definition that explains the LCC-specific angle. Avoid
+restating general assembler/VM/linker knowledge.
+
+**Source:** `src/core/<file>.js:<line-range>` (or function name)
+**See also:** [related-term-1], [related-term-2]
+```
+
+Cross-links use plain-text `[term-name]` refs within a file. Cross-file
+references use the standard `[term](other-file.md#anchor)` markdown form.

--- a/docs/glossary/assembler.md
+++ b/docs/glossary/assembler.md
@@ -1,0 +1,20 @@
+# Assembler Glossary
+
+Glossary of LCC-specific terms used in `src/core/assembler.js`.
+
+<!-- @todo #108:60m/WRITER Spike: read assembler.js (2295L) top-to-bottom and populate the candidate-term inventory below. Terms only, no definitions. See #108 -->
+<!-- @todo #111:60m/WRITER Write definitions for each inventoried term; LCC-specific angle only. Blocked by #108. See #111 -->
+
+Parent: #107 · See [README](./README.md) for entry conventions.
+
+---
+
+## Candidate term inventory (populated by spike #108)
+
+_To be filled in._
+
+---
+
+## Definitions (populated by write #111)
+
+_To be filled in after the spike completes._

--- a/docs/glossary/interpreter.md
+++ b/docs/glossary/interpreter.md
@@ -1,0 +1,20 @@
+# Interpreter Glossary
+
+Glossary of LCC-specific terms used in `src/core/interpreter.js`.
+
+<!-- @todo #109:60m/WRITER Spike: read interpreter.js (1753L) top-to-bottom and populate the candidate-term inventory below. Terms only, no definitions. See #109 -->
+<!-- @todo #112:60m/WRITER Write definitions for each inventoried term; LCC-specific angle only. Blocked by #109. See #112 -->
+
+Parent: #107 · See [README](./README.md) for entry conventions.
+
+---
+
+## Candidate term inventory (populated by spike #109)
+
+_To be filled in._
+
+---
+
+## Definitions (populated by write #112)
+
+_To be filled in after the spike completes._

--- a/docs/glossary/linker.md
+++ b/docs/glossary/linker.md
@@ -1,0 +1,20 @@
+# Linker Glossary
+
+Glossary of LCC-specific terms used in `src/core/linker.js`.
+
+<!-- @todo #110:60m/WRITER Spike: read linker.js (365L) top-to-bottom and populate the candidate-term inventory below. Terms only, no definitions. See #110 -->
+<!-- @todo #113:60m/WRITER Write definitions for each inventoried term; LCC-specific angle only. Blocked by #110. See #113 -->
+
+Parent: #107 · See [README](./README.md) for entry conventions.
+
+---
+
+## Candidate term inventory (populated by spike #110)
+
+_To be filled in._
+
+---
+
+## Definitions (populated by write #113)
+
+_To be filled in after the spike completes._


### PR DESCRIPTION
## Summary

- Scaffolds `docs/glossary/` with a README + three module stubs (assembler, interpreter, linker).
- Each stub carries spike + write `@todo` markers tied to the six child puzzles filed under parent #107.
- Adds one bullet to `TODOS.md` Documentation section pointing at #107.
- Addresses the long-standing ask in #9 with a concrete, decomposed plan.

No source code changed. Pure scaffolding — the actual term inventories + definitions land in follow-up puzzles.

## Issues filed

| # | Phase | Module | Est | Blocked by |
|---|---|---|---|---|
| #107 | Parent | — | — | — |
| #108 | Spike | assembler | 60m/WRITER | — |
| #111 | Write | assembler | 60m/WRITER | #108 |
| #109 | Spike | interpreter | 60m/WRITER | — |
| #112 | Write | interpreter | 60m/WRITER | #109 |
| #110 | Spike | linker | 60m/WRITER | — |
| #113 | Write | linker | 60m/WRITER | #110 |

## Test plan

- [ ] Pre-push PDD scan passes (already confirmed on `git push`)
- [ ] `docs/glossary/README.md` renders correctly on GitHub (table + entry convention block)
- [ ] `@todo` markers in the three stub files are discoverable via `grep -rn "@todo #" docs/`
- [ ] No unintended changes to source files

## Notes for the other agent on main

- The only shared file touched is `TODOS.md` (one added line under Documentation). If they also touch TODOS.md, expect a small conflict — resolve by keeping both bullets.
- All other changes are net-new files under `docs/glossary/`.
- Pre-push hook reported `0 puzzle(s) tracked` despite the 6 new `@todo` markers in `docs/glossary/` — the hook may only scan `src/`. Worth a follow-up to widen the scan if PDD coverage of docs is desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)