### PR TITLE
fix(showcase): add lineNumbers() to playground editor extensions

### DIFF
--- a/docs/site/showcase/index.html
+++ b/docs/site/showcase/index.html
@@ -152,7 +152,7 @@ code { font-family:var(--mono-font); }
 // subpackages; esm.sh cannot surface those re-exports regardless of ?bundle.
 // Fix: import each symbol from its source package, pinning them all to the same
 // @codemirror/state@6 instance via ?deps= so instanceof checks work. (#772)
-import { EditorView, keymap } from 'https://esm.sh/@codemirror/view@6?deps=@codemirror/state@6';
+import { EditorView, keymap, lineNumbers } from 'https://esm.sh/@codemirror/view@6?deps=@codemirror/state@6';
 import { basicSetup } from 'https://esm.sh/@codemirror/basic-setup@0.20?deps=@codemirror/state@6';
 import { indentWithTab, toggleLineComment } from 'https://esm.sh/@codemirror/commands@6?deps=@codemirror/state@6';
 import { autocompletion } from 'https://esm.sh/@codemirror/autocomplete@6?deps=@codemirror/state@6';
@@ -244,6 +244,7 @@ const editor = new EditorView({
   doc: "; helloWorld.a: print Hello, World! and halt\n        lea r0, msg\n        sout r0\n        nl\n        halt\nmsg:    .string \"Hello, World!\"",
   extensions: [
     basicSetup,
+    lineNumbers(),
     lcc(),
     syntaxHighlighting(defaultHighlightStyle),
     keymap.of([indentWithTab, { key: 'Mod-/', run: toggleLineComment }]),

--- a/scripts/build-site.js
+++ b/scripts/build-site.js
@@ -424,7 +424,7 @@ ${listItems}
 // subpackages; esm.sh cannot surface those re-exports regardless of ?bundle.
 // Fix: import each symbol from its source package, pinning them all to the same
 // @codemirror/state@6 instance via ?deps= so instanceof checks work. (#772)
-import { EditorView, keymap } from 'https://esm.sh/@codemirror/view@6?deps=@codemirror/state@6';
+import { EditorView, keymap, lineNumbers } from 'https://esm.sh/@codemirror/view@6?deps=@codemirror/state@6';
 import { basicSetup } from 'https://esm.sh/@codemirror/basic-setup@0.20?deps=@codemirror/state@6';
 import { indentWithTab, toggleLineComment } from 'https://esm.sh/@codemirror/commands@6?deps=@codemirror/state@6';
 import { autocompletion } from 'https://esm.sh/@codemirror/autocomplete@6?deps=@codemirror/state@6';
@@ -517,6 +517,7 @@ const editor = new EditorView({
   doc: ${starterCodeJson},
   extensions: [
     basicSetup,
+    lineNumbers(),
     lcc(),
     syntaxHighlighting(defaultHighlightStyle),
     keymap.of([indentWithTab, { key: 'Mod-/', run: toggleLineComment }]),


### PR DESCRIPTION
## Pull request overview

> [!NOTE]
> Copilot was unable to run its full agentic suite in this review.

The deployed playground at https://avidrucker.github.io/lccjs/showcase/ renders the CodeMirror 6 editor **without a line-number gutter** (`document.querySelector('.cm-gutters') → null`). Confirmed via local repro.

## Root cause

There are **two divergent showcase copies**, and #985's fix went to the wrong one for production:

- `docs/showcase/index.html` — a standalone *"Syntax Highlight Showcase"* page. **Not deployed.** #985 added explicit `lineNumbers()` here.
- `docs/site/showcase/index.html` — the **deployed Playground**, *generated* by `scripts/build-site.js` and uploaded as the Pages artifact (`docs/site` is the artifact root per `.github/workflows/pages.yml`). Its template uses bare `basicSetup` (`@codemirror/basic-setup@0.20`), whose gutter is inert under the @6 view — same symptom #985 describes — but it never received the `lineNumbers()` import.

## Changes

- `docs/site/showcase/index.html`: Added `lineNumbers` to the `@codemirror/view@6` ESM import and added `lineNumbers()` to the extensions array.
- `scripts/build-site.js`: Same fix applied to the embedded template so future builds include the gutter.

## Testing

1. `cd docs/site && python3 -m http.server 8766`
2. Open `http://localhost:8766/showcase/index.html`
3. `document.querySelector('.cm-gutters')` now returns the gutter element (not null)

Fixes #1024.